### PR TITLE
Enable dry-running addon sync

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
@@ -10,7 +11,11 @@ import (
 	"github.com/jim-minter/azure-helm/pkg/config"
 )
 
+var dryRun = flag.Bool("dry-run", false, "Print resources to be synced instead of mutating cluster state")
+
 func main() {
+	flag.Parse()
+
 	b, err := ioutil.ReadFile("_data/manifest.yaml")
 	if err != nil {
 		panic(err)
@@ -33,7 +38,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := addons.Main(m, c); err != nil {
+	if err := addons.Main(m, c, *dryRun); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -5,7 +5,9 @@ package addons
 //go:generate gofmt -s -l -w bindata.go
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"log"
 	"reflect"
 	"sort"
@@ -270,7 +272,7 @@ func getClients() (err error) {
 	return
 }
 
-func Main(m *api.Manifest, c *config.Config) error {
+func Main(m *api.Manifest, c *config.Config, dryRun bool) error {
 	err := getClients()
 	if err != nil {
 		return err
@@ -279,6 +281,17 @@ func Main(m *api.Manifest, c *config.Config) error {
 	db, err := readDB(m, c)
 	if err != nil {
 		return err
+	}
+
+	if dryRun {
+		var buf *bytes.Buffer
+		var p *YAMLPrinter
+		for _, obj := range db {
+			buf = bytes.NewBuffer(nil)
+			p.PrintObj(&obj, buf)
+			fmt.Println(string(buf.Bytes()))
+		}
+		return nil
 	}
 
 	err = writeDB(db)

--- a/pkg/addons/printers.go
+++ b/pkg/addons/printers.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addons
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/ghodss/yaml"
+)
+
+// YAMLPrinter is an implementation of ResourcePrinter which outputs an object as YAML.
+// The input object is assumed to be in the internal version of an API and is converted
+// to the given version first.
+type YAMLPrinter struct {
+	version   string
+	converter runtime.ObjectConvertor
+}
+
+// PrintObj prints the data as YAML.
+func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	// we use reflect.Indirect here in order to obtain the actual value from a pointer.
+	// we need an actual value in order to retrieve the package path for an object.
+	// using reflect.Indirect indiscriminately is valid here, as all runtime.Objects are supposed to be pointers.
+	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
+		return fmt.Errorf(InternalObjectPrinterErr)
+	}
+
+	switch obj := obj.(type) {
+	case *runtime.Unknown:
+		data, err := yaml.JSONToYAML(obj.Raw)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(data)
+		return err
+	}
+
+	if obj.GetObjectKind().GroupVersionKind().Empty() {
+		return fmt.Errorf("missing apiVersion or kind; try GetObjectKind().SetGroupVersionKind() if you know the type")
+	}
+
+	output, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(w, string(output))
+	return err
+}
+
+var (
+	InternalObjectPrinterErr = "a versioned object must be passed to a printer"
+
+	// disallowedPackagePrefixes contains regular expression templates
+	// for object package paths that are not allowed by printers.
+	disallowedPackagePrefixes = []string{
+		"k8s.io/kubernetes/pkg/apis/",
+	}
+)
+
+var InternalObjectPreventer = &illegalPackageSourceChecker{disallowedPackagePrefixes}
+
+func IsInternalObjectError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return err.Error() == InternalObjectPrinterErr
+}
+
+// illegalPackageSourceChecker compares a given
+// object's package path, and determines if the
+// object originates from a disallowed source.
+type illegalPackageSourceChecker struct {
+	// disallowedPrefixes is a slice of disallowed package path
+	// prefixes for a given runtime.Object that we are printing.
+	disallowedPrefixes []string
+}
+
+func (c *illegalPackageSourceChecker) IsForbidden(pkgPath string) bool {
+	for _, forbiddenPrefix := range c.disallowedPrefixes {
+		if strings.HasPrefix(pkgPath, forbiddenPrefix) || strings.Contains(pkgPath, "/vendor/"+forbiddenPrefix) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
@jim-minter @pweil- adds dry run for addons. I don't feel strong on how outputing the resources works (stdout vs generating all files in a directory even though I guess we want to latter for convenience). I am going to merge this for now since I need it for debugging.