### PR TITLE
Properly use helm for HCP pods

### DIFF
--- a/aks/create.sh
+++ b/aks/create.sh
@@ -24,3 +24,4 @@ az group deployment create -g $RESOURCEGROUP \
 az aks get-credentials -g $RESOURCEGROUP -n aks -f - >$(dirname $0)/admin.kubeconfig
 
 KUBECONFIG=$(dirname $0)/admin.kubeconfig kubectl create -f $(dirname $0)/ingress-nginx.yaml
+KUBECONFIG=$(dirname $0)/admin.kubeconfig kubectl create -f $(dirname $0)/tiller.yaml

--- a/aks/tiller.yaml
+++ b/aks/tiller.yaml
@@ -1,0 +1,89 @@
+# from
+# https://github.com/kubernetes/helm/blob/master/docs/rbac.md
+# and
+# helm init --service-account tiller --dry-run --debug
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: kube-system
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helm
+        name: tiller
+    spec:
+      containers:
+      - env:
+        - name: TILLER_NAMESPACE
+          value: kube-system
+        - name: TILLER_HISTORY_MAX
+          value: "0"
+        image: gcr.io/kubernetes-helm/tiller:v2.9.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        name: tiller
+        ports:
+        - containerPort: 44134
+          name: tiller
+        - containerPort: 44135
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+      serviceAccountName: tiller
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: kube-system
+spec:
+  ports:
+  - name: tiller
+    port: 44134
+    targetPort: tiller
+  selector:
+    app: helm
+    name: tiller
+  type: ClusterIP

--- a/create.sh
+++ b/create.sh
@@ -68,10 +68,7 @@ go run cmd/createorupdate/createorupdate.go
 
 az group deployment create -g $RESOURCEGROUP -n azuredeploy --template-file _data/_out/azuredeploy.json --no-wait
 
-# poor man's helm (without tiller running)
-helm template pkg/helm/chart -f _data/_out/values.yaml --output-dir _data/_out
-KUBECONFIG=aks/admin.kubeconfig kubectl create namespace $RESOURCEGROUP
-KUBECONFIG=aks/admin.kubeconfig kubectl apply -n $RESOURCEGROUP -Rf _data/_out/osa/templates
+KUBECONFIG=aks/admin.kubeconfig helm install --namespace $RESOURCEGROUP pkg/helm/chart -f _data/_out/values.yaml -n $RESOURCEGROUP >/dev/null
 
 while true; do
     HCPINGRESSIP=$(KUBECONFIG=aks/admin.kubeconfig kubectl get ingress -n $RESOURCEGROUP master-api -o template --template '{{ if .status.loadBalancer }}{{ (index .status.loadBalancer.ingress 0).ip }}{{ end }}')

--- a/delete.sh
+++ b/delete.sh
@@ -1,5 +1,24 @@
 #!/bin/bash -x
 
+if [[ ! -e aks/admin.kubeconfig ]]; then
+    echo error: aks/admin.kubeconfig must exist
+    exit 1
+fi
+
+if ! az account show >/dev/null; then
+    exit 1
+fi
+
+if [[ -z "$DNS_DOMAIN" ]]; then
+    echo error: must set DNS_DOMAIN
+    exit 1
+fi
+
+if [[ -z "$DNS_RESOURCEGROUP" ]]; then
+    echo error: must set DNS_RESOURCEGROUP
+    exit 1
+fi
+
 if [[ ! -e _data/manifest.yaml ]]; then
     echo error: _data/manifest.yaml must exist
     exit 1
@@ -7,6 +26,14 @@ fi
 
 PUBLICHOSTNAME=$(awk '/^PublicHostname:/ { print $2 }' <_data/manifest.yaml)
 RESOURCEGROUP=$(awk '/^ResourceGroup:/ { print $2 }' <_data/manifest.yaml)
+
+KUBECONFIG=aks/admin.kubeconfig helm delete --purge $RESOURCEGROUP >/dev/null
+
+# k8s 1.10.3 seems to be very slow about removing terminating pods when their
+# namespace is also terminating, so wait up.
+while [[ $(KUBECONFIG=aks/admin.kubeconfig kubectl get pods -n $RESOURCEGROUP -o template --template '{{ len .items }}') -ne 0 ]]; do
+    sleep 1
+done
 
 KUBECONFIG=aks/admin.kubeconfig kubectl delete namespace $RESOURCEGROUP
 

--- a/pkg/helm/chart/templates/Deployment.apps/bootstrap-autoapprover.yaml
+++ b/pkg/helm/chart/templates/Deployment.apps/bootstrap-autoapprover.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bootstrap-autoapprover
+  annotations:
+    checksum/bootstrap-autoapprover-kubeconfig: {{ include (print $.Template.BasePath "/Secret/bootstrap-autoapprover-kubeconfig.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:

--- a/pkg/helm/chart/templates/Deployment.apps/master-api.yaml
+++ b/pkg/helm/chart/templates/Deployment.apps/master-api.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: master-api
+  annotations:
+    checksum/etc-origin-master: {{ include (print $.Template.BasePath "/Secret/etc-origin-master.yaml") . | sha256sum }}
+    checksum/etc-origin-cloudprovider: {{ include (print $.Template.BasePath "/Secret/etc-origin-cloudprovider.yaml") . | sha256sum }}
+    checksum/tunnel: {{ include (print $.Template.BasePath "/Secret/tunnel.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:

--- a/pkg/helm/chart/templates/Deployment.apps/master-controllers.yaml
+++ b/pkg/helm/chart/templates/Deployment.apps/master-controllers.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: master-controllers
+  annotations:
+    checksum/etc-origin-master: {{ include (print $.Template.BasePath "/Secret/etc-origin-master.yaml") . | sha256sum }}
+    checksum/etc-origin-cloudprovider: {{ include (print $.Template.BasePath "/Secret/etc-origin-cloudprovider.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:

--- a/pkg/helm/chart/templates/Deployment.apps/master-etcd.yaml
+++ b/pkg/helm/chart/templates/Deployment.apps/master-etcd.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: master-etcd
+  annotations:
+    checksum/etc-etcd: {{ include (print $.Template.BasePath "/Secret/etc-etcd.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:

--- a/pkg/helm/chart/templates/Deployment.apps/servicecatalog-api.yaml
+++ b/pkg/helm/chart/templates/Deployment.apps/servicecatalog-api.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: servicecatalog-api
+  annotations:
+    checksum/servicecatalog-api: {{ include (print $.Template.BasePath "/Secret/servicecatalog-api.yaml") . | sha256sum }}
+    checksum/servicecatalog-api-kubeconfig: {{ include (print $.Template.BasePath "/Secret/servicecatalog-api-kubeconfig.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:

--- a/pkg/helm/chart/templates/Deployment.apps/sync.yaml
+++ b/pkg/helm/chart/templates/Deployment.apps/sync.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sync
+  annotations:
+    checksum/sync: {{ include (print $.Template.BasePath "/Secret/sync.yaml") . | sha256sum }}
+    checksum/admin-kubeconfig: {{ include (print $.Template.BasePath "/Secret/admin-kubeconfig.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:

--- a/pkg/helm/chart/templates/Secret/admin-kubeconfig.yaml
+++ b/pkg/helm/chart/templates/Secret/admin-kubeconfig.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: admin-kubeconfig
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   admin.kubeconfig: {{ .Values.AdminKubeconfig }}
 {{end}}

--- a/pkg/helm/chart/templates/Secret/bootstrap-autoapprover-kubeconfig.yaml
+++ b/pkg/helm/chart/templates/Secret/bootstrap-autoapprover-kubeconfig.yaml
@@ -2,5 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: bootstrap-autoapprover-kubeconfig
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   bootstrap-autoapprover.kubeconfig: {{ .Values.BootstrapAutoapproverKubeconfig }}

--- a/pkg/helm/chart/templates/Secret/etc-etcd.yaml
+++ b/pkg/helm/chart/templates/Secret/etc-etcd.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: etc-etcd
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   ca.crt: {{ .Values.EtcdCaCert }}
   server.crt: {{ .Values.EtcdServerCert }}

--- a/pkg/helm/chart/templates/Secret/etc-origin-cloudprovider.yaml
+++ b/pkg/helm/chart/templates/Secret/etc-origin-cloudprovider.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: etc-origin-cloudprovider
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 stringData:
   azure.conf: |
     tenantId: {{ .Values.TenantID }}

--- a/pkg/helm/chart/templates/Secret/etc-origin-master.yaml
+++ b/pkg/helm/chart/templates/Secret/etc-origin-master.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: etc-origin-master
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   master.etcd-ca.crt: {{ .Values.EtcdCaCert }}
   ca.crt: {{ .Values.CaCert }}

--- a/pkg/helm/chart/templates/Secret/servicecatalog-api-kubeconfig.yaml
+++ b/pkg/helm/chart/templates/Secret/servicecatalog-api-kubeconfig.yaml
@@ -2,5 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: servicecatalog-api-kubeconfig
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   servicecatalog-api.kubeconfig: {{ .Values.ServiceCatalogAPIKubeconfig }}

--- a/pkg/helm/chart/templates/Secret/servicecatalog-api.yaml
+++ b/pkg/helm/chart/templates/Secret/servicecatalog-api.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: servicecatalog-api
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   etcd-ca.crt: {{ .Values.EtcdCaCert }}
   etcd-client.crt: {{ .Values.EtcdClientCert }}

--- a/pkg/helm/chart/templates/Secret/sync.yaml
+++ b/pkg/helm/chart/templates/Secret/sync.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: sync
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 stringData:
   config.yaml: |
     AlertManagerProxySessionSecret: {{ .Values.AlertManagerProxySessionSecret }}

--- a/pkg/helm/chart/templates/Secret/tunnel.yaml
+++ b/pkg/helm/chart/templates/Secret/tunnel.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: tunnel
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
 data:
   ca.crt: {{ .Values.CaCert }}
   tunnel.crt: {{ .Values.TunnelCert }}

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -5,9 +5,7 @@ RESOURCEGROUP=$(awk '/^ResourceGroup:/ { print $2 }' <_data/manifest.yaml)
 go generate ./...
 go run cmd/createorupdate/createorupdate.go
 
-# poor man's helm (without tiller running)
-helm template pkg/helm/chart -f _data/_out/values.yaml --output-dir _data/_out
-KUBECONFIG=aks/admin.kubeconfig kubectl apply -n $RESOURCEGROUP -Rf _data/_out/osa/templates
+KUBECONFIG=aks/admin.kubeconfig helm upgrade $RESOURCEGROUP pkg/helm/chart -f _data/_out/values.yaml >/dev/null
 
 # TODO: need to apply ARM deployment changes
 


### PR DESCRIPTION
* Install tiller into AKS cluster
* Use helm/tiller for HCP create/upgrade/delete
* Use checksums to auto-kick HCP pods when their configs change
  (and always lay down secrets before deployments on upgrade)