### PR TITLE
readding admin.kubeconfig secret to HCP

### DIFF
--- a/pkg/helm/chart/templates/Deployment.apps/sync.yaml
+++ b/pkg/helm/chart/templates/Deployment.apps/sync.yaml
@@ -34,5 +34,5 @@ spec:
           secretName: sync
       - name: kubeconfig
         secret:
-          secretName: admin-kubeconfig # TODO: need to use a less powerful token
+          secretName: admin-kubeconfig
 {{end}}

--- a/pkg/helm/chart/templates/Secret/admin-kubeconfig.yaml
+++ b/pkg/helm/chart/templates/Secret/admin-kubeconfig.yaml
@@ -1,0 +1,8 @@
+{{if 0}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-kubeconfig
+data:
+  admin.kubeconfig: {{ .Values.AdminKubeconfig }}
+{{end}}


### PR DESCRIPTION
@kargakis fyi - I think the sync pod fundamentally requires the admin.kubeconfig.