### PR TITLE
add BYO vnet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,58 @@
    `./ssh.sh hostname`.
 
 1. Run `./delete.sh` to delete the deployed cluster.
+
+### Examples
+
+Basic OpenShift configuration:
+
+```yaml
+name: openshift
+location: eastus
+properties:
+  openShiftVersion: "$DEPLOY_VERSION"
+  publicHostname: openshift.$RESOURCEGROUP.$DNS_DOMAIN
+  routingConfigSubdomain: $RESOURCEGROUP.$DNS_DOMAIN
+  agentPoolProfiles:
+  - name: compute
+    count: 1
+    vmSize: Standard_D2s_v3
+  - name: infra
+    role: infra
+    count: 1
+    vmSize: Standard_D2s_v3
+  servicePrincipalProfile:
+    clientID: $AZURE_CLIENT_ID
+    secret: $AZURE_CLIENT_SECRET
+```
+
+OpenShift with BYO VNET configuration:
+
+```yaml
+name: openshift
+location: eastus
+properties:
+  openShiftVersion: "$DEPLOY_VERSION"
+  publicHostname: openshift.$RESOURCEGROUP.$DNS_DOMAIN
+  routingConfigSubdomain: $RESOURCEGROUP.$DNS_DOMAIN
+  agentPoolProfiles:
+  - name: compute
+    count: 1
+    vmSize: Standard_D2s_v3
+    vnetSubnetID: /subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME
+  - name: infra
+    role: infra
+    count: 1
+    vmSize: Standard_D2s_v3
+    vnetSubnetID: /subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME
+  servicePrincipalProfile:
+    clientID: $AZURE_CLIENT_ID
+    secret: $AZURE_CLIENT_SECRET
+```
+
+You can create BYO VNET and subnet with commands:
+
+```bash
+az network vnet create -n $VNET_NAME -l $LOCATION -g $RESOURCEGROUP
+az network vnet subnet create -n $SUBNET_NAME -g $RESOURCEGROUP --vnet-name $VNET_NAME --address-prefix 10.0.0.0/24
+```

--- a/pkg/arm/data/azuredeploy.json
+++ b/pkg/arm/data/azuredeploy.json
@@ -4,82 +4,7 @@
     "parameters": {},
     "variables": {},
     "resources": [
-        {
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "apiVersion": "2016-03-30",
-            "location": "{{ .ContainerService.Location | js }}",
-            "name": "nsg-compute",
-            "properties": {
-                "securityRules": [
-                    {
-                        "name": "allow_ssh",
-                        "properties": {
-                            "access": "Allow",
-                            "description": "Allow SSH traffic",
-                            "destinationAddressPrefix": "*",
-                            "destinationPortRange": "22-22",
-                            "direction": "Inbound",
-                            "priority": 101,
-                            "protocol": "Tcp",
-                            "sourceAddressPrefix": "*",
-                            "sourcePortRange": "*"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "apiVersion": "2016-03-30",
-            "location": "{{ .ContainerService.Location | js }}",
-            "name": "nsg-infra",
-            "properties": {
-                "securityRules": [
-                    {
-                        "name": "allow_ssh",
-                        "properties": {
-                            "access": "Allow",
-                            "description": "Allow SSH traffic",
-                            "destinationAddressPrefix": "*",
-                            "destinationPortRange": "22-22",
-                            "direction": "Inbound",
-                            "priority": 101,
-                            "protocol": "Tcp",
-                            "sourceAddressPrefix": "*",
-                            "sourcePortRange": "*"
-                        }
-                    },
-                    {
-                        "name": "allow_http",
-                        "properties": {
-                            "access": "Allow",
-                            "description": "Allow http traffic",
-                            "destinationAddressPrefix": "*",
-                            "destinationPortRange": "80",
-                            "direction": "Inbound",
-                            "priority": 102,
-                            "protocol": "Tcp",
-                            "sourceAddressPrefix": "*",
-                            "sourcePortRange": "*"
-                        }
-                    },
-                    {
-                        "name": "allow_https",
-                        "properties": {
-                            "access": "Allow",
-                            "description": "Allow https traffic",
-                            "destinationAddressPrefix": "*",
-                            "destinationPortRange": "443",
-                            "direction": "Inbound",
-                            "priority": 103,
-                            "protocol": "Tcp",
-                            "sourceAddressPrefix": "*",
-                            "sourcePortRange": "*"
-                        }
-                    }
-                ]
-            }
-        },
+{{ if not ( index .ContainerService.Properties.AgentPoolProfiles 0).VnetSubnetID }}              
         {
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2016-03-30",
@@ -93,7 +18,7 @@
                 },
                 "subnets": [
                     {
-                        "name": "subnet",
+                        "name": "default",
                         "properties": {
                             "addressPrefix": "10.0.0.0/24"
                         }
@@ -101,6 +26,7 @@
                 ]
             }
         },
+{{ end }}
         {
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "2016-03-30",
@@ -217,24 +143,83 @@
             "properties": {
                 "accountType": "Standard_LRS"
             }
+        }
+{{- range $app := .ContainerService.Properties.AgentPoolProfiles }},
+       {
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "apiVersion": "2016-03-30",
+            "location": "{{ $.ContainerService.Location }}",
+            "name": "nsg-{{ $app.Name }}",
+            "properties": {
+                "securityRules": [
+                    {
+                        "name": "allow_ssh",
+                        "properties": {
+                            "access": "Allow",
+                            "description": "Allow SSH traffic",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "22-22",
+                            "direction": "Inbound",
+                            "priority": 101,
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "*",
+                            "sourcePortRange": "*"
+                    }
+                }
+{{ if eq $app.Role `infra` }}  
+                    ,{
+                        "name": "allow_http",
+                        "properties": {
+                            "access": "Allow",
+                            "description": "Allow http traffic",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "80",
+                            "direction": "Inbound",
+                            "priority": 102,
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "*",
+                            "sourcePortRange": "*"
+                        }
+                    },
+                    {
+                        "name": "allow_https",
+                        "properties": {
+                            "access": "Allow",
+                            "description": "Allow https traffic",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "443",
+                            "direction": "Inbound",
+                            "priority": 103,
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "*",
+                            "sourcePortRange": "*"
+                        }
+                    }
+{{ end }}
+                ]
+            }
         },
+
         {
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "apiVersion": "2017-12-01",
-            "location": "{{ .ContainerService.Location | js }}",
+            "location": "{{ $.ContainerService.Location | js }}",
             "dependsOn": [
+{{ if eq $app.Role `infra` }}                
+                "[resourceId('Microsoft.Network/loadBalancers', 'lb-router')]",
+{{ end }}
+{{ if not $app.VnetSubnetID }}
                 "[resourceId('Microsoft.Network/virtualNetworks', 'vnet')]",
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-compute')]"
+{{ end }}
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-{{ $app.Name }}')]"
             ],
-            "name": "ss-compute",
+            "name": "ss-{{ $app.Name }}",
             "sku": {
                 "tier": "Standard",
-{{- range $app := .ContainerService.Properties.AgentPoolProfiles }}{{ if eq $app.Name `compute` }}
                 "capacity": "{{ $app.Count | js }}",
                 "name": "{{ $app.VMSize | js }}"
-{{- end }}{{ end }}
             },
-{{- if eq .Config.ImageResourceName "" }}
+{{- if eq $.Config.ImageResourceName "" }}
             "plan": {
                 "name": "{{ .Config.ImageSKU | js }}",
                 "publisher": "{{ .Config.ImagePublisher | js }}",
@@ -249,13 +234,13 @@
                 "virtualMachineProfile": {
                     "osProfile": {
                         "adminUsername": "cloud-user",
-                        "computerNamePrefix": "compute-",
+                        "computerNamePrefix": "{{ $app.Name }}-",
                         "linuxConfiguration": {
                             "disablePasswordAuthentication": true,
                             "ssh": {
                                 "publicKeys": [
                                     {
-                                        "keyData": "{{ SSHPublicKeyAsString .Config.SSHKey.PublicKey | js }}",
+                                        "keyData": "{{ SSHPublicKeyAsString $.Config.SSHKey.PublicKey }}",
                                         "path": "/home/cloud-user/.ssh/authorized_keys"
                                     }
                                 ]
@@ -264,13 +249,13 @@
                     },
                     "storageProfile": {
                         "imageReference": {
-{{- if eq .Config.ImageResourceName "" }}
-                            "offer": "{{ .Config.ImageOffer | js }}",
-                            "publisher": "{{ .Config.ImagePublisher | js }}",
-                            "sku": "{{ .Config.ImageSKU | js }}",
-                            "version": "{{ .Config.ImageVersion | js }}"
+{{- if eq $.Config.ImageResourceName "" }}
+                            "offer": "{{ $.Config.ImageOffer | js }}",
+                            "publisher": "{{ $.Config.ImagePublisher | js }}",
+                            "sku": "{{ $.Config.ImageSKU | js }}",
+                            "version": "{{ $.Config.ImageVersion | js }}"
 {{- else }}
-                            "id": "[resourceId('{{ .Config.ImageResourceGroup | js }}', 'Microsoft.Compute/images', '{{ .Config.ImageResourceName | js }}')]"
+                            "id": "[resourceId('{{ $.Config.ImageResourceGroup | js }}', 'Microsoft.Compute/images', '{{ $.Config.ImageResourceName | js }}')]"
 {{- end }}
                         },
                         "osDisk": {
@@ -289,7 +274,7 @@
                                     "primary": true,
                                     "enableIPForwarding": true,
                                     "networkSecurityGroup": {
-                                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-compute')]"
+                                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-{{ $app.Name }}')]"
                                     },
                                     "ipConfigurations": [
                                         {
@@ -297,7 +282,11 @@
                                             "properties": {
                                                 "primary": true,
                                                 "subnet": {
-                                                    "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', 'vnet'), '/subnets/subnet')]"
+{{ if $app.VnetSubnetID }}
+                                                    "id": "{{ $app.VnetSubnetID }}"
+{{ else }}
+                                                    "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', 'vnet'), '/subnets/default')]"
+{{ end }}
                                                 },
                                                 "publicIpAddressConfiguration": {
                                                     "name": "ip",
@@ -305,126 +294,13 @@
                                                         "idleTimeoutInMinutes": 15
                                                     }
                                                 }
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    },
-                    "extensionProfile": {
-                        "extensions": [
-                            {
-                                "name": "cse",
-                                "properties": {
-                                    "autoUpgradeMinorVersion": true,
-                                    "protectedSettings": {
-                                        "script": "{{ Base64Encode (Startup `compute`) | js }}"
-                                    },
-                                    "publisher": "Microsoft.Azure.Extensions",
-                                    "settings": {},
-                                    "type": "CustomScript",
-                                    "typeHandlerVersion": "2.0"
-                                }
-                            }
-                        ]
-                    }
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachineScaleSets",
-            "apiVersion": "2017-12-01",
-            "location": "{{ .ContainerService.Location | js }}",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', 'vnet')]",
-                "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-infra')]",
-                "[resourceId('Microsoft.Network/loadBalancers', 'lb-router')]"
-            ],
-            "name": "ss-infra",
-            "sku": {
-                "tier": "Standard",
-{{- range $app := .ContainerService.Properties.AgentPoolProfiles }}{{ if eq $app.Name `infra` }}
-                "capacity": "{{ $app.Count | js }}",
-                "name": "{{ $app.VMSize | js }}"
-{{- end }}{{ end }}
-            },
-{{- if eq .Config.ImageResourceName "" }}
-            "plan": {
-                "name": "{{ .Config.ImageSKU | js }}",
-                "publisher": "{{ .Config.ImagePublisher | js }}",
-                "product": "{{ .Config.ImageOffer | js }}"
-            },
-{{- end }}
-            "properties": {
-                "overprovision": false,
-                "upgradePolicy": {
-                    "mode": "Manual"
-                },
-                "virtualMachineProfile": {
-                    "osProfile": {
-                        "adminUsername": "cloud-user",
-                        "computerNamePrefix": "infra-",
-                        "linuxConfiguration": {
-                            "disablePasswordAuthentication": true,
-                            "ssh": {
-                                "publicKeys": [
-                                    {
-                                        "keyData": "{{ SSHPublicKeyAsString .Config.SSHKey.PublicKey | js }}",
-                                        "path": "/home/cloud-user/.ssh/authorized_keys"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "storageProfile": {
-                        "imageReference": {
-{{- if eq .Config.ImageResourceName "" }}
-                            "offer": "{{ .Config.ImageOffer | js }}",
-                            "publisher": "{{ .Config.ImagePublisher | js }}",
-                            "sku": "{{ .Config.ImageSKU | js }}",
-                            "version": "{{ .Config.ImageVersion | js }}"
-{{- else }}
-                            "id": "[resourceId('{{ .Config.ImageResourceGroup | js }}', 'Microsoft.Compute/images', '{{ .Config.ImageResourceName | js }}')]"
-{{- end }}
-                        },
-                        "osDisk": {
-                            "caching": "ReadWrite",
-                            "createOption": "FromImage",
-                            "managedDisk": {
-                                "storageAccountType": "Premium_LRS"
-                            }
-                        }
-                    },
-                    "networkProfile": {
-                        "networkInterfaceConfigurations": [
-                            {
-                                "name": "nic",
-                                "properties": {
-                                    "primary": true,
-                                    "enableIPForwarding": true,
-                                    "networkSecurityGroup": {
-                                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'nsg-infra')]"
-                                    },
-                                    "ipConfigurations": [
-                                        {
-                                            "name": "ipconfig",
-                                            "properties": {
-                                                "primary": true,
-                                                "subnet": {
-                                                    "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', 'vnet'), '/subnets/subnet')]"
-                                                },
-                                                "publicIpAddressConfiguration": {
-                                                    "name": "ip",
-                                                    "properties": {
-                                                        "idleTimeoutInMinutes": 15
-                                                    }
-                                                },
-                                                "loadBalancerBackendAddressPools": [
+{{ if eq $app.Role `infra` }}  
+                                                ,"loadBalancerBackendAddressPools": [
                                                     {
                                                         "id": "[concat(resourceId('Microsoft.Network/loadBalancers', 'lb-router'), '/backendAddressPools/backend')]"
                                                     }
                                                 ]
+{{ end }}
                                             }
                                         }
                                     ]
@@ -439,7 +315,7 @@
                                 "properties": {
                                     "autoUpgradeMinorVersion": true,
                                     "protectedSettings": {
-                                        "script": "{{ Base64Encode (Startup `infra`) | js }}"
+                                        "script": "{{ Base64Encode (Startup $app.Name ) }}"
                                     },
                                     "publisher": "Microsoft.Azure.Extensions",
                                     "settings": {},
@@ -452,6 +328,7 @@
                 }
             }
         }
+{{ end }}
     ],
     "outputs": {}
 }


### PR DESCRIPTION
At this point in time, I loop over scaleset so it has less code but mode complex logic. And this partially enables multiple compute pools in api model. Are we fine proceeding this way or better stick with bigger file and simpler json logic.
If we go this way of the loop we might want to create a separate security group for each pool? Or we just stick with 2 (nsg-infra and ngs-compute)? I would create a new one for each poll.