### PR TITLE
add ability to change and inject oreg_url and resolve multiple images

### DIFF
--- a/env.example
+++ b/env.example
@@ -9,6 +9,9 @@ export DNS_RESOURCEGROUP=dns
 # Set the OpenShift version (3.10) (mandatory)
 export DEPLOY_VERSION=3.10
 
+# Set OREG_URL to overwrite registry and namespace. Used for testing.
+#export OREG_URL='registry.reg-aws.openshift.com/openshift3/ose-${component}:${version}'
+
 # If deploying CentOS/origin, uncomment this section, otherwise do nothing
 # TODO: centos7 is the only deployment that works atm, use that as a default
 export DEPLOY_OS=centos7


### PR DESCRIPTION
Image resolve part is needed for HCP layer to work with private and testing images. This is because AKS is ignoring oreg_url as such.

This works fine with RHEL builds, but I have doubts about CI testing:
when `OREG_URL=registry.svc.ci.openshift.org/ci-pr-images/prtest-89730d6-17-${component}:${version}`
Images get these names. I need to add logic to modify image names for this too, but I don't think we required all images and all of them will be available with the same name. For CI we might need to modify just subset of images.

```
MasterEtcdImage: "registry.svc.ci.openshift.org/ci-pr-images/etcd:v3.10"
MasterAPIImage: "registry.svc.ci.openshift.org/ci-pr-images/ose-control-plane:v3.10"
MasterControllersImage: "registry.svc.ci.openshift.org/ci-pr-images/ose-control-plane:v3.10"
NodeImage: "registry.svc.ci.openshift.org/ci-pr-images/ose-node:v3.10"
```