### PR TITLE
fix for services

### DIFF
--- a/pkg/addons/clean.go
+++ b/pkg/addons/clean.go
@@ -120,10 +120,6 @@ func Clean(o unstructured.Unstructured) error {
 
 	case "Service":
 		jsonpath.MustCompile("$.metadata.annotations.'service.alpha.openshift.io/serving-cert-signed-by'").Delete(o.Object)
-		// for LoadBalancer type we need to preserve clusterIP
-		if o.Object["spec"].(map[string]interface{})["type"] != "LoadBalancer" {
-			jsonpath.MustCompile("$.spec.clusterIP").Delete(o.Object)
-		}
 
 	case "ServiceAccount":
 		// TODO: the intention is to remove references to automatically created
@@ -159,9 +155,10 @@ func handleSpecialObjects(existing, o unstructured.Unstructured) {
 	case "Service":
 		// copy existing clusterIP new object
 		if existing.Object["spec"].(map[string]interface{})["type"] == "LoadBalancer" {
-			o.Object["spec"].(map[string]interface{})["clusterIP"] = existing.Object["spec"].(map[string]interface{})["clusterIP"]
 			o.Object["spec"].(map[string]interface{})["externalTrafficPolicy"] = existing.Object["spec"].(map[string]interface{})["externalTrafficPolicy"]
 			o.Object["spec"].(map[string]interface{})["ports"] = existing.Object["spec"].(map[string]interface{})["ports"]
 		}
+		// ClusterIP is immutable. Copy it over for update
+		o.Object["spec"].(map[string]interface{})["clusterIP"] = existing.Object["spec"].(map[string]interface{})["clusterIP"]
 	}
 }

--- a/pkg/addons/client.go
+++ b/pkg/addons/client.go
@@ -193,12 +193,14 @@ func write(dyn dynamic.ClientPool, grs []*discovery.APIGroupResources, o *unstru
 			return
 		}
 		Default(*existing)
-		handleSpecialObjects(*existing, *o)
 
 		if reflect.DeepEqual(*existing, *o) {
 			log.Println("Skip " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
 			return
 		}
+		// this part of code should be executed only for updates
+		// TODO: Split flows to separate functions
+		handleSpecialObjects(*existing, *o)
 
 		log.Println("Update " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
 


### PR DESCRIPTION
@jim-minter @kargakis @kwoodson @pweil- 

All services object is immutable when updating due `clusterIP`.
Any service which needs updating will trigger an error with immutable field https://github.com/jim-minter/azure-helm/issues/103

`handleSpecialObjects` was introduced to handle cases like this.
If service gets updated we need to add clusterIP manually (L164) because DeepCopy does not copy this field. (so cleaning of the existing is just removing data we need) 
